### PR TITLE
Fix inactive bug & performance enhancements

### DIFF
--- a/LEColorPicker/LEColorPicker.h
+++ b/LEColorPicker/LEColorPicker.h
@@ -46,7 +46,6 @@
     CAEAGLLayer* _eaglLayer;
     EAGLContext *_context;
     dispatch_queue_t taskQueue;
-    BOOL _isWorking;
 }
 /**
  This instance method allows the client object to generate three colors from a specific UIImage. This method generate synchronously colors for background, primary and secondary colors, encapsulated in a LEColorScheme object.


### PR DESCRIPTION
I've made some changes to LEColorPicker for my purposes and to fix some bugs
- Removed `UIApplicationStateInactive` from isActive requirement (#6)
- Fixed LEColorPicker worker queue becoming permanently suspended when coming back from being inactive (since there is no complementary state notification for `UIApplicationWillResignActiveNotification` and since `dispatch_suspend` and `dispatch_resume` nest inside themselves)
- Added shared instance of LEColorPicker for class method
- Added specific target queue assignment for worker queue
- Using a shared context for GL since all work is done on a serial queue

Feel free to take them, modify them, or whatever. The bug fixes should for sure be useful for someone. I'm currently using these in production without issue with a ton of images in a collection view and this is performing nicely.
